### PR TITLE
fix for IHUBH-88,107 and 108.

### DIFF
--- a/data/org.eclipse.birt.data.oda.mongodb.ui/src/org/eclipse/birt/data/oda/mongodb/ui/impl/MongoDBDataSourcePageHelper.java
+++ b/data/org.eclipse.birt.data.oda.mongodb.ui/src/org/eclipse/birt/data/oda/mongodb/ui/impl/MongoDBDataSourcePageHelper.java
@@ -731,24 +731,29 @@ public class MongoDBDataSourcePageHelper
 			properties = new Properties( );
 		}
 
-		if ( serverHost != null )
-			properties.setProperty( MongoDBDriver.SERVER_HOST_PROP, serverHost );
+		if ( URIElementsRadioBtn.getSelection( ) == true )
+		{
+			if ( serverHost != null )
+				properties.setProperty( MongoDBDriver.SERVER_HOST_PROP, serverHost );
 
-		if ( serverPort != null )
-			properties.setProperty( MongoDBDriver.SERVER_PORT_PROP, serverPort );
+			if ( serverPort != null )
+				properties.setProperty( MongoDBDriver.SERVER_PORT_PROP, serverPort );
 
-		if ( dbName != null )
-			properties.setProperty( MongoDBDriver.DBNAME_PROP, dbName );
+			if ( dbName != null )
+				properties.setProperty( MongoDBDriver.DBNAME_PROP, dbName );
 
-		if ( userName != null )
-			properties.setProperty( MongoDBDriver.USERNAME_PROP, userName );
+			if ( userName != null )
+				properties.setProperty( MongoDBDriver.USERNAME_PROP, userName );
 
-		if ( password != null )
-			properties.setProperty( MongoDBDriver.PASSWORD_PROP, password );
-
-		if ( dbURI != null )
-			properties.setProperty( MongoDBDriver.MONGO_URI_PROP, dbURI );
-
+			if ( password != null )
+				properties.setProperty( MongoDBDriver.PASSWORD_PROP, password );
+		}
+		else if ( URIElementsRadioBtn.getSelection( ) == false )
+		{
+			if ( dbURI != null )
+				properties.setProperty( MongoDBDriver.MONGO_URI_PROP, dbURI );
+		}
+		
 		properties.setProperty( MongoDBDriver.IGNORE_URI_PROP,
 				Boolean.toString( URIElementsRadioBtn.getSelection( ) || UIHelper.isEmptyString( dbURI ) ) );
 

--- a/data/org.eclipse.birt.data.oda.mongodb/META-INF/MANIFEST.MF
+++ b/data/org.eclipse.birt.data.oda.mongodb/META-INF/MANIFEST.MF
@@ -19,4 +19,5 @@ Import-Package: com.mongodb;version="3.2.2",
  com.mongodb.util;version="3.2.2",
  org.apache.commons.codec.binary;version="1.6.0",
  org.bson;version="3.2.2",
+ org.bson.conversions;version="3.2.2",
  org.bson.types;version="3.2.2"

--- a/data/org.eclipse.birt.data.oda.mongodb/plugin.properties
+++ b/data/org.eclipse.birt.data.oda.mongodb/plugin.properties
@@ -25,7 +25,6 @@ datasource.property.databaseName=&Database Name
 datasource.property.userName=U&ser Name
 datasource.property.password=Pass&word
 datasource.property.socketKeepAlive=Keep Socket &Alive
-datasource.property.useRequestSession=Consistent &Request Session
 datasource.property.group.uriElements=Mongo Database URI &Elements
 datasource.property.group.options=Supplemental Client &Setting(s)
 

--- a/data/org.eclipse.birt.data.oda.mongodb/plugin.xml
+++ b/data/org.eclipse.birt.data.oda.mongodb/plugin.xml
@@ -104,25 +104,6 @@
 	                     value="false">
 	               </choice>
 	            </property>
-	            <property
-	                  allowsEmptyValueAsNull="true"
-	                  canInherit="true"
-	                  defaultDisplayName="%datasource.property.useRequestSession"
-	                  defaultValue="false"
-	                  isEncryptable="false"
-	                  name="useRequestSession"
-	                  type="choice">
-	 	              <choice
-		                     defaultDisplayName="yes"
-		                     name="true"
-		                     value="true">
-		              </choice>
-		              <choice
-		                     defaultDisplayName="no"
-		                     name="false"
-		                     value="false">
-		              </choice>
-	            </property>
             </propertyGroup>
          </properties>
       </dataSource>

--- a/data/org.eclipse.birt.data.oda.mongodb/src/org/eclipse/birt/data/oda/mongodb/impl/MongoDBDriver.java
+++ b/data/org.eclipse.birt.data.oda.mongodb/src/org/eclipse/birt/data/oda/mongodb/impl/MongoDBDriver.java
@@ -437,10 +437,17 @@ public class MongoDBDriver implements IDriver
 
 	private static MongoClientURI getMongoURI( Properties connProps )
 	{
-		return getMongoURI( connProps, null );
+		try
+		{
+			return getMongoURI( connProps, null );
+		}
+		catch ( Exception e )
+		{
+			return null;
+		}
 	}
 
-	private static MongoClientURI getMongoURI( Properties connProps, MongoClientOptions.Builder clientOptionsBuilder )
+	private static MongoClientURI getMongoURI( Properties connProps, MongoClientOptions.Builder clientOptionsBuilder ) throws Exception
 	{
 		// check if explicitly indicated not to use URI, even if URI value
 		// exists
@@ -468,8 +475,9 @@ public class MongoDBDriver implements IDriver
 			// log and ignore
 			getLogger( ).log( Level.INFO, Messages.bind( "Invalid Mongo Database URI: {0}", uri ), //$NON-NLS-1$
 					ex );
+			throw ex;
 		}
-		return null;
+		//return null;
 	}
 
 	/*


### PR DESCRIPTION
IHUBH-88 {Mongo 3.2 Driver} Remove “Consistent Request Session” in Property Binding of 3.x Mongodb UI plugin
 data/org.eclipse.birt.data.oda.mongodb/plugin.properties
 data/org.eclipse.birt.data.oda.mongodb/plugin.xml

 Changes in above files are related to IHub-88

IHUBH-107 {Mongo 3.2 Driver} Test Connection is failing from analytics designer 
 data/org.eclipse.birt.data.oda.mongodb/META-INF/MANIFEST.MF

 Changes in above files are related to IHub-107

IHUBH-108 {Mongo 3.2} mongo 3.2 test connection is succeeded for negative scenarios as well 
 mongodb.ui/src/org/eclipse/birt/data/oda/mongodb/ui/impl/MongoDBDataSourcePageHelper.java
 org.eclipse.birt.data.oda.mongodb/src/org/eclipse/birt/data/oda/mongodb/impl/MongoDBDriver.java

 Changes in above files are related to IHub-108.
